### PR TITLE
Gold House MVP: deployable display + Netlify config

### DIFF
--- a/app/api/footprint/route.ts
+++ b/app/api/footprint/route.ts
@@ -7,10 +7,10 @@ export async function GET(req: Request) {
   const lng = Number(url.searchParams.get("lng"));
   try {
     const result = await fetchFootprint(lat, lng);
-    if (result === null) {
-      return NextResponse.json({ result: null });
-    }
-    return NextResponse.json({ result });
+    return NextResponse.json(
+      { result },
+      { headers: { "cache-control": "public, max-age=3600" } }
+    );
   } catch (err) {
     if (err instanceof FootprintError) {
       return NextResponse.json(

--- a/app/api/geocode/route.ts
+++ b/app/api/geocode/route.ts
@@ -6,7 +6,9 @@ export async function GET(req: Request) {
   const address = url.searchParams.get("address") ?? "";
   try {
     const result = await geocodeAddress(address);
-    return NextResponse.json(result);
+    return NextResponse.json(result, {
+      headers: { "cache-control": "public, max-age=3600" },
+    });
   } catch (err) {
     if (err instanceof GeocodeError) {
       return NextResponse.json(

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import { CommodityPicker } from "@/components/CommodityPicker";
 import { IsoViz } from "@/components/IsoViz";
 import { FallbackForm } from "@/components/FallbackForm";
 import { ShareButton } from "@/components/ShareButton";
+import { DemoPresets } from "@/components/DemoPresets";
 import { clientFetchers, fetchPrices } from "@/lib/clientFetchers";
 import { computeForState, type ComputeResult } from "@/lib/pipeline";
 import { parseSearchParams, toQueryString } from "@/lib/urlState";
@@ -68,7 +69,7 @@ function PageInner() {
   }, [state.address, state.commodity, state.sqft, state.value]);
 
   function handleAddressSubmit(address: string) {
-    updateUrl({ ...state, address });
+    updateUrl({ address, commodity: state.commodity });
   }
 
   function handleCommodityChange(id: CommodityId) {
@@ -79,25 +80,58 @@ function PageInner() {
     updateUrl({ ...state, sqft, value });
   }
 
+  function handlePresetPick(next: UrlState) {
+    updateUrl({ ...next, commodity: state.commodity });
+  }
+
+  function handleReset() {
+    router.replace("/");
+    setResult(null);
+  }
+
   const showFallback = result?.kind === "needs-manual";
   const errorMessage =
-    result?.kind === "error" ? result.message : undefined;
+    result?.kind === "error" ? humanizeError(result.message) : undefined;
+  const hasResult = result?.kind === "ok";
+  const showLanding = !state.address && !loading;
 
   return (
-    <main className="mx-auto max-w-2xl px-4 py-10">
-      <header className="mb-8 flex items-center justify-between">
-        <h1 className="text-2xl font-semibold tracking-tight">
-          Gold House
-        </h1>
+    <main className="mx-auto max-w-2xl px-4 py-8 sm:py-12">
+      <header className="mb-6 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={handleReset}
+          className="text-left"
+          aria-label="Home"
+        >
+          <div className="text-xl font-semibold tracking-tight">
+            <span aria-hidden>🏠</span> Gold House
+          </div>
+        </button>
         {state.address && <ShareButton />}
       </header>
 
-      <div className="space-y-6">
+      {showLanding && (
+        <div className="mb-6 text-center sm:text-left">
+          <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">
+            How tall is your home in <span className="text-amber-700">gold</span>?
+          </h1>
+          <p className="mt-2 text-stone-600">
+            Enter a US home address — we&apos;ll show how high a solid block of
+            gold, oil, or sugar worth its assessed value would stack on its
+            footprint.
+          </p>
+        </div>
+      )}
+
+      <div className="space-y-5">
         <AddressInput
           initial={state.address}
           onSubmit={handleAddressSubmit}
           error={errorMessage ?? null}
         />
+
+        {showLanding && <DemoPresets onPick={handlePresetPick} />}
 
         <CommodityPicker
           selected={state.commodity}
@@ -105,8 +139,17 @@ function PageInner() {
         />
 
         {loading && (
-          <div className="text-center text-stone-500" role="status">
-            Crunching numbers…
+          <div
+            className="rounded-2xl border border-stone-200 bg-white px-6 py-12 text-center text-stone-500"
+            role="status"
+          >
+            <div className="inline-flex items-center gap-2">
+              <span
+                className="inline-block h-3 w-3 animate-pulse rounded-full bg-amber-700"
+                aria-hidden
+              />
+              Crunching numbers…
+            </div>
           </div>
         )}
 
@@ -114,12 +157,26 @@ function PageInner() {
           <FallbackForm onSubmit={handleManualSubmit} />
         )}
 
-        {!loading && result?.kind === "ok" && <IsoViz result={result} />}
+        {!loading && hasResult && <IsoViz result={result} />}
       </div>
 
       <footer className="mt-12 text-center text-xs text-stone-400">
-        Free data — Nominatim · OpenStreetMap · prices may be cached
+        Free data: Nominatim · OpenStreetMap. Commodity prices use the
+        bundled fallback snapshot.
       </footer>
     </main>
   );
+}
+
+function humanizeError(raw: string): string {
+  if (/non[_ -]?us/i.test(raw) || /US addresses only/i.test(raw)) {
+    return "US addresses only for now.";
+  }
+  if (/find that address|no result|not found/i.test(raw)) {
+    return "We couldn't find that address. Try including city and state.";
+  }
+  if (/502|network|nominatim/i.test(raw)) {
+    return "Geocoding is temporarily unavailable. Try a sample below or enter sqft + value manually.";
+  }
+  return raw;
 }

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "react-dom": "^19.0.0",
       },
       "devDependencies": {
+        "@netlify/plugin-nextjs": "^5.13.0",
         "@tailwindcss/postcss": "^4.0.0",
         "@types/bun": "^1.1.13",
         "@types/node": "^22.9.0",
@@ -85,6 +86,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@netlify/plugin-nextjs": ["@netlify/plugin-nextjs@5.15.11", "", {}, "sha512-cx7yoJFYDBFRecGqJaEUuvnHvU+vs9ISn7DUXyijPheaqtbyRy4+z7Mjre9swEJ19ItVeFhuGuXUkl6X5nfJeA=="],
 
     "@next/env": ["@next/env@15.5.18", "", {}, "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g=="],
 

--- a/components/DemoPresets.tsx
+++ b/components/DemoPresets.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { DEMO_PRESETS } from "@/lib/demoPresets";
+import type { UrlState } from "@/lib/types";
+
+export function DemoPresets({
+  onPick,
+}: {
+  onPick: (state: UrlState) => void;
+}) {
+  return (
+    <div>
+      <div className="mb-2 text-xs uppercase tracking-wide text-stone-500">
+        Or try a sample
+      </div>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {DEMO_PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            onClick={() => onPick(preset.state)}
+            className="flex flex-col items-start rounded-lg border border-stone-200 bg-white px-3 py-2 text-left transition hover:border-amber-700 hover:bg-amber-50"
+          >
+            <span className="text-sm font-medium text-stone-800">
+              {preset.label}
+            </span>
+            <span className="text-xs text-stone-500">{preset.hint}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/FallbackForm.tsx
+++ b/components/FallbackForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type FormEvent } from "react";
+import { isPositiveFinite } from "@/lib/math";
 
 export function FallbackForm({
   onSubmit,
@@ -14,8 +15,7 @@ export function FallbackForm({
     e.preventDefault();
     const s = Number(sqft);
     const v = Number(value);
-    if (!Number.isFinite(s) || s <= 0) return;
-    if (!Number.isFinite(v) || v <= 0) return;
+    if (!isPositiveFinite(s) || !isPositiveFinite(v)) return;
     onSubmit({ sqft: s, value: v });
   }
 

--- a/components/IsoViz.tsx
+++ b/components/IsoViz.tsx
@@ -3,55 +3,149 @@
 import { COMMODITIES } from "@/lib/commodities";
 import type { ComputeResult } from "@/lib/pipeline";
 
-export function IsoViz({ result }: { result: Extract<ComputeResult, { kind: "ok" }> }) {
-  const config = COMMODITIES[result.commodity];
-  const height = result.heightM;
+const VIZ_HEIGHT_PX = 360;
+const COLUMN_WIDTH_PX = 88;
+const REFERENCE_COL_WIDTH_PX = 64;
 
-  // Bar height scales logarithmically so 1 m and 1000 m both look meaningful.
-  const barPct = Math.min(100, Math.max(5, 20 + Math.log10(Math.max(1, height)) * 20));
+export function IsoViz({
+  result,
+}: {
+  result: Extract<ComputeResult, { kind: "ok" }>;
+}) {
+  const config = COMMODITIES[result.commodity];
+  const heightM = result.heightM;
+  const ref = result.reference;
+
+  // Pixels-per-meter is chosen so the *column* fills VIZ_HEIGHT_PX. The
+  // reference glyph(s) are sized in the same scale, so the side-by-side
+  // comparison is proportionally honest.
+  const pxPerMeter = VIZ_HEIGHT_PX / heightM;
+  const refGlyphPx = Math.max(
+    14,
+    Math.min(140, ref.object.heightM * pxPerMeter)
+  );
+  const columnPx = VIZ_HEIGHT_PX;
+
+  const stackedCount = ref.overflow ? Math.floor(ref.count) : ref.count;
+  // Tilt the column with a tiny shadow on the right face for depth.
+  const lightColor = config.color;
+  const darkColor = darken(lightColor, 0.18);
 
   return (
     <section className="rounded-2xl border border-stone-200 bg-white px-6 py-8 shadow-sm">
-      <div className="text-center">
-        <div className="text-5xl font-bold tabular-nums">
-          {formatMeters(height)}
+      <div className="flex flex-col items-center gap-1">
+        <div className="text-5xl font-bold tabular-nums tracking-tight">
+          {formatMeters(heightM)}
         </div>
-        <div className="mt-1 text-sm text-stone-500">
-          tall block of {config.label.toLowerCase()}
+        <div className="text-sm text-stone-500">
+          solid block of {config.label.toLowerCase()}
         </div>
       </div>
 
-      <div className="mt-8 flex items-end justify-center" aria-hidden>
+      <div
+        className="mt-8 flex items-end justify-center gap-6"
+        style={{ height: VIZ_HEIGHT_PX + 40 }}
+        aria-label={`Visualization: ${formatMeters(heightM)} tower next to ${ref.label}`}
+      >
+        {/* Commodity column */}
+        <div className="flex flex-col items-center">
+          <div
+            className="flex overflow-hidden rounded-t-md shadow-sm"
+            style={{
+              width: COLUMN_WIDTH_PX,
+              height: columnPx,
+            }}
+          >
+            <div
+              style={{
+                background: lightColor,
+                width: "70%",
+                borderRight: `1px solid ${darkColor}`,
+              }}
+            />
+            <div
+              style={{
+                background: darkColor,
+                width: "30%",
+              }}
+            />
+          </div>
+          <div className="mt-2 text-xs font-medium text-stone-500">
+            {config.emoji} {config.label}
+          </div>
+        </div>
+
+        {/* Reference stack */}
         <div
-          className="w-24 rounded-t-md"
-          style={{
-            backgroundColor: config.color,
-            height: `${barPct}%`,
-            minHeight: 60,
-            maxHeight: 280,
-          }}
-        />
+          className="flex flex-col items-center justify-end"
+          style={{ width: REFERENCE_COL_WIDTH_PX, height: columnPx }}
+        >
+          {ref.overflow ? (
+            <div
+              className="flex flex-col items-center justify-end"
+              style={{ height: columnPx }}
+            >
+              <div
+                style={{ fontSize: refGlyphPx, lineHeight: 1 }}
+                aria-hidden
+              >
+                {ref.object.glyph}
+              </div>
+              <div className="mt-1 text-xs text-stone-500 text-center">
+                ×{ref.count.toFixed(1)}
+              </div>
+            </div>
+          ) : (
+            <div
+              className="flex flex-col-reverse items-center"
+              style={{ height: columnPx }}
+            >
+              {Array.from({ length: stackedCount }).map((_, i) => (
+                <div
+                  key={i}
+                  style={{
+                    fontSize: refGlyphPx,
+                    lineHeight: 1,
+                    height: refGlyphPx,
+                  }}
+                  aria-hidden
+                >
+                  {ref.object.glyph}
+                </div>
+              ))}
+            </div>
+          )}
+          <div className="mt-2 text-xs font-medium text-stone-500 text-center">
+            {ref.object.label}
+          </div>
+        </div>
       </div>
 
-      <div className="mt-6 text-center text-lg text-stone-700">
-        {result.reference.label}
+      <div className="mt-2 border-t border-stone-200" />
+
+      <div className="mt-4 text-center text-base text-stone-700">
+        {ref.label}
       </div>
 
-      <dl className="mt-8 grid grid-cols-2 gap-x-6 gap-y-2 text-sm text-stone-600">
+      <dl className="mt-6 grid grid-cols-2 gap-x-6 gap-y-1.5 text-sm text-stone-600">
         <dt>Home value</dt>
         <dd className="text-right tabular-nums">
           ${result.assessedValue.toLocaleString()}
         </dd>
         <dt>Footprint area</dt>
         <dd className="text-right tabular-nums">
-          {result.footprintAreaM2.toFixed(1)} m²
+          {result.footprintAreaM2.toFixed(0)} m²
         </dd>
         <dt>{config.label} price</dt>
         <dd className="text-right tabular-nums">
-          ${Math.round(result.pricePerM3).toLocaleString()} / m³
+          ${formatBigUSD(result.pricePerM3)} / m³
         </dd>
-        <dt>Footprint source</dt>
-        <dd className="text-right">{result.source.footprint}</dd>
+        <dt>Data source</dt>
+        <dd className="text-right text-stone-500">
+          {result.source.footprint === "manual"
+            ? "manual entry"
+            : `${result.source.footprint} · ${result.source.value}`}
+        </dd>
       </dl>
     </section>
   );
@@ -61,4 +155,27 @@ function formatMeters(m: number): string {
   if (m < 0.1) return `${(m * 100).toFixed(1)} cm`;
   if (m < 1000) return `${m.toFixed(1)} m`;
   return `${(m / 1000).toFixed(2)} km`;
+}
+
+function formatBigUSD(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(2)}B`;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toFixed(0);
+}
+
+/** Darken a #RRGGBB hex color by `amount` (0–1). Returns hex. */
+function darken(hex: string, amount: number): string {
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex);
+  if (!m) return hex;
+  const v = parseInt(m[1], 16);
+  const r = Math.max(0, Math.min(255, ((v >> 16) & 0xff) * (1 - amount)));
+  const g = Math.max(0, Math.min(255, ((v >> 8) & 0xff) * (1 - amount)));
+  const b = Math.max(0, Math.min(255, (v & 0xff) * (1 - amount)));
+  return (
+    "#" +
+    [r, g, b]
+      .map((x) => Math.round(x).toString(16).padStart(2, "0"))
+      .join("")
+  );
 }

--- a/components/IsoViz.tsx
+++ b/components/IsoViz.tsx
@@ -1,11 +1,18 @@
 "use client";
 
 import { COMMODITIES } from "@/lib/commodities";
+import { formatBigUSD, formatMeters } from "@/lib/formatting";
 import type { ComputeResult } from "@/lib/pipeline";
+import type { ReferencePick } from "@/lib/scaleReference";
 
 const VIZ_HEIGHT_PX = 360;
 const COLUMN_WIDTH_PX = 88;
 const REFERENCE_COL_WIDTH_PX = 64;
+// Hard cap on stacked glyphs to keep DOM bounded; beyond this we render
+// the overflow form (×N) even when the reference math has count <= cap.
+const MAX_RENDERED_STACK = 20;
+const MIN_GLYPH_PX = 14;
+const MAX_GLYPH_PX = 140;
 
 export function IsoViz({
   result,
@@ -16,20 +23,12 @@ export function IsoViz({
   const heightM = result.heightM;
   const ref = result.reference;
 
-  // Pixels-per-meter is chosen so the *column* fills VIZ_HEIGHT_PX. The
-  // reference glyph(s) are sized in the same scale, so the side-by-side
-  // comparison is proportionally honest.
   const pxPerMeter = VIZ_HEIGHT_PX / heightM;
   const refGlyphPx = Math.max(
-    14,
-    Math.min(140, ref.object.heightM * pxPerMeter)
+    MIN_GLYPH_PX,
+    Math.min(MAX_GLYPH_PX, ref.object.heightM * pxPerMeter)
   );
-  const columnPx = VIZ_HEIGHT_PX;
-
-  const stackedCount = ref.overflow ? Math.floor(ref.count) : ref.count;
-  // Tilt the column with a tiny shadow on the right face for depth.
-  const lightColor = config.color;
-  const darkColor = darken(lightColor, 0.18);
+  const darkColor = darken(config.color, 0.18);
 
   return (
     <section className="rounded-2xl border border-stone-200 bg-white px-6 py-8 shadow-sm">
@@ -47,78 +46,13 @@ export function IsoViz({
         style={{ height: VIZ_HEIGHT_PX + 40 }}
         aria-label={`Visualization: ${formatMeters(heightM)} tower next to ${ref.label}`}
       >
-        {/* Commodity column */}
-        <div className="flex flex-col items-center">
-          <div
-            className="flex overflow-hidden rounded-t-md shadow-sm"
-            style={{
-              width: COLUMN_WIDTH_PX,
-              height: columnPx,
-            }}
-          >
-            <div
-              style={{
-                background: lightColor,
-                width: "70%",
-                borderRight: `1px solid ${darkColor}`,
-              }}
-            />
-            <div
-              style={{
-                background: darkColor,
-                width: "30%",
-              }}
-            />
-          </div>
-          <div className="mt-2 text-xs font-medium text-stone-500">
-            {config.emoji} {config.label}
-          </div>
-        </div>
-
-        {/* Reference stack */}
-        <div
-          className="flex flex-col items-center justify-end"
-          style={{ width: REFERENCE_COL_WIDTH_PX, height: columnPx }}
-        >
-          {ref.overflow ? (
-            <div
-              className="flex flex-col items-center justify-end"
-              style={{ height: columnPx }}
-            >
-              <div
-                style={{ fontSize: refGlyphPx, lineHeight: 1 }}
-                aria-hidden
-              >
-                {ref.object.glyph}
-              </div>
-              <div className="mt-1 text-xs text-stone-500 text-center">
-                ×{ref.count.toFixed(1)}
-              </div>
-            </div>
-          ) : (
-            <div
-              className="flex flex-col-reverse items-center"
-              style={{ height: columnPx }}
-            >
-              {Array.from({ length: stackedCount }).map((_, i) => (
-                <div
-                  key={i}
-                  style={{
-                    fontSize: refGlyphPx,
-                    lineHeight: 1,
-                    height: refGlyphPx,
-                  }}
-                  aria-hidden
-                >
-                  {ref.object.glyph}
-                </div>
-              ))}
-            </div>
-          )}
-          <div className="mt-2 text-xs font-medium text-stone-500 text-center">
-            {ref.object.label}
-          </div>
-        </div>
+        <CommodityColumn
+          emoji={config.emoji}
+          label={config.label}
+          lightColor={config.color}
+          darkColor={darkColor}
+        />
+        <ReferenceStack ref={ref} glyphPx={refGlyphPx} />
       </div>
 
       <div className="mt-2 border-t border-stone-200" />
@@ -151,20 +85,121 @@ export function IsoViz({
   );
 }
 
-function formatMeters(m: number): string {
-  if (m < 0.1) return `${(m * 100).toFixed(1)} cm`;
-  if (m < 1000) return `${m.toFixed(1)} m`;
-  return `${(m / 1000).toFixed(2)} km`;
+function CommodityColumn({
+  emoji,
+  label,
+  lightColor,
+  darkColor,
+}: {
+  emoji: string;
+  label: string;
+  lightColor: string;
+  darkColor: string;
+}) {
+  return (
+    <div className="flex flex-col items-center">
+      <div
+        className="flex overflow-hidden rounded-t-md shadow-sm"
+        style={{ width: COLUMN_WIDTH_PX, height: VIZ_HEIGHT_PX }}
+      >
+        <div
+          style={{
+            background: lightColor,
+            width: "70%",
+            borderRight: `1px solid ${darkColor}`,
+          }}
+        />
+        <div style={{ background: darkColor, width: "30%" }} />
+      </div>
+      <div className="mt-2 text-xs font-medium text-stone-500">
+        {emoji} {label}
+      </div>
+    </div>
+  );
 }
 
-function formatBigUSD(n: number): string {
-  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(2)}B`;
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return n.toFixed(0);
+function ReferenceStack({
+  ref,
+  glyphPx,
+}: {
+  ref: ReferencePick;
+  glyphPx: number;
+}) {
+  const stackedCount = ref.overflow ? Math.floor(ref.count) : ref.count;
+  const tooManyToStack = stackedCount > MAX_RENDERED_STACK;
+  const useCompact = ref.overflow || tooManyToStack;
+
+  return (
+    <div
+      className="flex flex-col items-center justify-end"
+      style={{ width: REFERENCE_COL_WIDTH_PX, height: VIZ_HEIGHT_PX }}
+    >
+      {useCompact ? (
+        <CompactReference ref={ref} glyphPx={glyphPx} />
+      ) : (
+        <StackedReference
+          glyph={ref.object.glyph}
+          count={stackedCount}
+          glyphPx={glyphPx}
+        />
+      )}
+      <div className="mt-2 text-xs font-medium text-stone-500 text-center">
+        {ref.object.label}
+      </div>
+    </div>
+  );
 }
 
-/** Darken a #RRGGBB hex color by `amount` (0–1). Returns hex. */
+function CompactReference({
+  ref,
+  glyphPx,
+}: {
+  ref: ReferencePick;
+  glyphPx: number;
+}) {
+  const multiplier = ref.overflow ? ref.count.toFixed(1) : String(ref.count);
+  return (
+    <div
+      className="flex flex-col items-center justify-end"
+      style={{ height: VIZ_HEIGHT_PX }}
+    >
+      <div style={{ fontSize: glyphPx, lineHeight: 1 }} aria-hidden>
+        {ref.object.glyph}
+      </div>
+      <div className="mt-1 text-xs text-stone-500 text-center">
+        ×{multiplier}
+      </div>
+    </div>
+  );
+}
+
+function StackedReference({
+  glyph,
+  count,
+  glyphPx,
+}: {
+  glyph: string;
+  count: number;
+  glyphPx: number;
+}) {
+  return (
+    <div
+      className="flex flex-col-reverse items-center"
+      style={{ height: VIZ_HEIGHT_PX }}
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <div
+          key={i}
+          style={{ fontSize: glyphPx, lineHeight: 1, height: glyphPx }}
+          aria-hidden
+        >
+          {glyph}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function darken(hex: string, amount: number): string {
   const m = /^#?([0-9a-f]{6})$/i.exec(hex);
   if (!m) return hex;

--- a/lib/clientFetchers.ts
+++ b/lib/clientFetchers.ts
@@ -19,11 +19,17 @@ async function getJson<T>(path: string): Promise<T> {
   return body as T;
 }
 
+function buildUrl(path: string, params: Record<string, string | number>): string {
+  const sp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) sp.set(k, String(v));
+  return `${path}?${sp.toString()}`;
+}
+
 export const clientFetchers: Fetchers = {
   geocode: async (address) => {
     try {
       return await getJson<GeocodeResult>(
-        `/api/geocode?address=${encodeURIComponent(address)}`
+        buildUrl("/api/geocode", { address })
       );
     } catch (err) {
       throw new GeocodeError("NO_RESULT", (err as Error).message);
@@ -32,7 +38,7 @@ export const clientFetchers: Fetchers = {
   footprint: async (lat, lng) => {
     try {
       const { result } = await getJson<{ result: FootprintResult | null }>(
-        `/api/footprint?lat=${lat}&lng=${lng}`
+        buildUrl("/api/footprint", { lat, lng })
       );
       return result;
     } catch (err) {
@@ -41,7 +47,7 @@ export const clientFetchers: Fetchers = {
   },
   assessor: async ({ address, lat, lng }: AssessorQuery) => {
     const { result } = await getJson<{ result: AssessorResult | null }>(
-      `/api/assessor?address=${encodeURIComponent(address)}&lat=${lat}&lng=${lng}`
+      buildUrl("/api/assessor", { address, lat, lng })
     );
     return result;
   },

--- a/lib/demoPresets.ts
+++ b/lib/demoPresets.ts
@@ -1,0 +1,64 @@
+import type { UrlState } from "./types";
+
+export type DemoPreset = {
+  id: string;
+  /** Short label for the button. */
+  label: string;
+  /** Sub-label (e.g., neighborhood / market). */
+  hint: string;
+  /** URL state that resolves directly via the manual-fallback path. */
+  state: UrlState;
+};
+
+/**
+ * Curated example homes. Each preset carries an explicit sqft + value so the
+ * pipeline can render immediately without depending on Nominatim/OSM/ATTOM.
+ *
+ * Numbers are illustrative round figures, not real assessments.
+ */
+export const DEMO_PRESETS: DemoPreset[] = [
+  {
+    id: "detroit-cottage",
+    label: "Detroit cottage",
+    hint: "$65k · 950 sqft",
+    state: {
+      address: "Detroit, MI (sample)",
+      commodity: "gold",
+      sqft: 950,
+      value: 65_000,
+    },
+  },
+  {
+    id: "austin-ranch",
+    label: "Austin ranch",
+    hint: "$550k · 1,800 sqft",
+    state: {
+      address: "Austin, TX (sample)",
+      commodity: "gold",
+      sqft: 1_800,
+      value: 550_000,
+    },
+  },
+  {
+    id: "brooklyn-brownstone",
+    label: "Brooklyn brownstone",
+    hint: "$2.1M · 2,400 sqft",
+    state: {
+      address: "Brooklyn, NY (sample)",
+      commodity: "gold",
+      sqft: 2_400,
+      value: 2_100_000,
+    },
+  },
+  {
+    id: "beverly-hills-mansion",
+    label: "Beverly Hills mansion",
+    hint: "$18M · 9,500 sqft",
+    state: {
+      address: "Beverly Hills, CA (sample)",
+      commodity: "gold",
+      sqft: 9_500,
+      value: 18_000_000,
+    },
+  },
+];

--- a/lib/formatting.ts
+++ b/lib/formatting.ts
@@ -1,0 +1,12 @@
+export function formatMeters(m: number): string {
+  if (m < 0.1) return `${(m * 100).toFixed(1)} cm`;
+  if (m < 1000) return `${m.toFixed(1)} m`;
+  return `${(m / 1000).toFixed(2)} km`;
+}
+
+export function formatBigUSD(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(2)}B`;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toFixed(0);
+}

--- a/lib/math.ts
+++ b/lib/math.ts
@@ -3,6 +3,10 @@ import type { HeightComputationInput, Polygon } from "./types";
 const SQFT_TO_SQM = 0.0929;
 const METERS_PER_DEG_LAT = 111_320;
 
+export function isPositiveFinite(n: unknown): n is number {
+  return typeof n === "number" && Number.isFinite(n) && n > 0;
+}
+
 export function sqFtToSqM(sqft: number): number {
   if (sqft < 0) throw new Error("sqft must be non-negative");
   return sqft * SQFT_TO_SQM;

--- a/lib/scaleReference.ts
+++ b/lib/scaleReference.ts
@@ -10,6 +10,8 @@ export type ReferenceObject = {
   heightM: number;
   svgFile: string;
   maxMultiple: number;
+  /** Single-glyph stand-in used by IsoViz until proper SVGs land. */
+  glyph: string;
 };
 
 export const REFERENCE_OBJECTS: ReferenceObject[] = [
@@ -19,6 +21,7 @@ export const REFERENCE_OBJECTS: ReferenceObject[] = [
     heightM: 0.00085,
     svgFile: "credit-card.svg",
     maxMultiple: 5,
+    glyph: "💳",
   },
   {
     id: "human",
@@ -26,6 +29,7 @@ export const REFERENCE_OBJECTS: ReferenceObject[] = [
     heightM: 1.7,
     svgFile: "human.svg",
     maxMultiple: 5,
+    glyph: "🧍",
   },
   {
     id: "telephone-pole",
@@ -33,6 +37,7 @@ export const REFERENCE_OBJECTS: ReferenceObject[] = [
     heightM: 12,
     svgFile: "telephone-pole.svg",
     maxMultiple: 5,
+    glyph: "📏",
   },
   {
     id: "statue-of-liberty",
@@ -40,6 +45,7 @@ export const REFERENCE_OBJECTS: ReferenceObject[] = [
     heightM: 93,
     svgFile: "statue-of-liberty.svg",
     maxMultiple: 5,
+    glyph: "🗽",
   },
   {
     id: "eiffel-tower",
@@ -47,6 +53,7 @@ export const REFERENCE_OBJECTS: ReferenceObject[] = [
     heightM: 330,
     svgFile: "eiffel-tower.svg",
     maxMultiple: 5,
+    glyph: "🗼",
   },
   {
     id: "burj-khalifa",
@@ -54,6 +61,7 @@ export const REFERENCE_OBJECTS: ReferenceObject[] = [
     heightM: 828,
     svgFile: "burj-khalifa.svg",
     maxMultiple: 5,
+    glyph: "🏙️",
   },
 ];
 

--- a/lib/urlState.ts
+++ b/lib/urlState.ts
@@ -1,3 +1,4 @@
+import { isPositiveFinite } from "./math";
 import type { CommodityId, UrlState } from "./types";
 
 const VALID_COMMODITIES = new Set<CommodityId>(["gold", "oil", "sugar"]);
@@ -12,8 +13,7 @@ function asCommodity(raw: string | null): CommodityId {
 function asPositiveNumber(raw: string | null): number | undefined {
   if (raw === null) return undefined;
   const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) return undefined;
-  return n;
+  return isPositiveFinite(n) ? n : undefined;
 }
 
 export function parseSearchParams(sp: URLSearchParams): UrlState {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,10 @@
 # Netlify configuration for the Gold House Next.js app.
-# The official @netlify/plugin-nextjs runtime is auto-installed by Netlify
-# for Next.js projects and handles SSR + API routes.
+#
+# The Next.js runtime (@netlify/plugin-nextjs) transforms the .next output
+# into Netlify serverless functions + edge redirects so the App Router and
+# /api/* routes work. It is declared explicitly below because Netlify's
+# auto-install of the runtime can miss projects that use bun.lock instead
+# of package-lock.json.
 
 [build]
   command = "bun run build"
@@ -8,7 +12,9 @@
 
 [build.environment]
   NODE_VERSION = "22"
-  # Bun is auto-detected from bun.lock, but pin the version for reproducibility.
+  # Bun is auto-detected from bun.lock; pin the version for reproducibility.
   BUN_VERSION = "1.3.11"
-  # Next.js 15 sometimes warns about telemetry on first build — silence it.
   NEXT_TELEMETRY_DISABLED = "1"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,14 @@
+# Netlify configuration for the Gold House Next.js app.
+# The official @netlify/plugin-nextjs runtime is auto-installed by Netlify
+# for Next.js projects and handles SSR + API routes.
+
+[build]
+  command = "bun run build"
+  publish = ".next"
+
+[build.environment]
+  NODE_VERSION = "22"
+  # Bun is auto-detected from bun.lock, but pin the version for reproducibility.
+  BUN_VERSION = "1.3.11"
+  # Next.js 15 sometimes warns about telemetry on first build — silence it.
+  NEXT_TELEMETRY_DISABLED = "1"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@netlify/plugin-nextjs": "^5.13.0",
     "@types/bun": "^1.1.13",
     "@types/node": "^22.9.0",
     "@types/react": "^19.0.0",

--- a/tests/demoPresets.test.ts
+++ b/tests/demoPresets.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { DEMO_PRESETS } from "@/lib/demoPresets";
+import { computeForState } from "@/lib/pipeline";
+import { FALLBACK_PRICES } from "@/lib/commodities";
+
+const NEVER_CALLED_FETCHERS = {
+  geocode: async () => {
+    throw new Error("demo presets must not hit the network");
+  },
+  footprint: async () => {
+    throw new Error("demo presets must not hit the network");
+  },
+  assessor: async () => {
+    throw new Error("demo presets must not hit the network");
+  },
+};
+
+describe("DEMO_PRESETS", () => {
+  test("has stable IDs (no duplicates)", () => {
+    const ids = DEMO_PRESETS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("every preset resolves to a positive height without network", async () => {
+    for (const preset of DEMO_PRESETS) {
+      const r = await computeForState(
+        preset.state,
+        FALLBACK_PRICES,
+        NEVER_CALLED_FETCHERS
+      );
+      expect(r.kind).toBe("ok");
+      if (r.kind !== "ok") continue;
+      expect(r.heightM).toBeGreaterThan(0);
+      expect(Number.isFinite(r.heightM)).toBe(true);
+    }
+  });
+
+  test("every preset has both sqft and value (manual-fallback ready)", () => {
+    for (const preset of DEMO_PRESETS) {
+      expect(preset.state.sqft).toBeGreaterThan(0);
+      expect(preset.state.value).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/formatting.test.ts
+++ b/tests/formatting.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { formatBigUSD, formatMeters } from "@/lib/formatting";
+
+describe("formatMeters", () => {
+  test("uses cm under 0.1 m", () => {
+    expect(formatMeters(0.05)).toBe("5.0 cm");
+  });
+
+  test("uses m between 0.1 and 1000", () => {
+    expect(formatMeters(47.3)).toBe("47.3 m");
+    expect(formatMeters(0.5)).toBe("0.5 m");
+  });
+
+  test("uses km at or above 1000 m", () => {
+    expect(formatMeters(1234)).toBe("1.23 km");
+  });
+});
+
+describe("formatBigUSD", () => {
+  test("formats billions", () => {
+    expect(formatBigUSD(1_500_000_000)).toBe("1.50B");
+  });
+  test("formats millions", () => {
+    expect(formatBigUSD(2_300_000)).toBe("2.30M");
+  });
+  test("formats thousands", () => {
+    expect(formatBigUSD(4_500)).toBe("4.5K");
+  });
+  test("formats small numbers as integers", () => {
+    expect(formatBigUSD(42)).toBe("42");
+  });
+});

--- a/tests/scaleReference.test.ts
+++ b/tests/scaleReference.test.ts
@@ -23,6 +23,12 @@ describe("REFERENCE_OBJECTS", () => {
       "burj-khalifa",
     ]);
   });
+
+  test("every object has a glyph", () => {
+    for (const r of REFERENCE_OBJECTS) {
+      expect(r.glyph).toBeTruthy();
+    }
+  });
 });
 
 describe("pickReference", () => {


### PR DESCRIPTION
Continues the MVP rebuild from PR #11 and gets the app to a state Netlify can deploy and demo.

## Summary
- Full repo wipe of the legacy Rust/Python code and rebuild as a Next.js 15 + TypeScript + Bun project (App Router, Tailwind v4).
- Data-flow first: every `lib/` module is TDD'd with `bun test` (71 tests, 161 assertions, all green).
- `IsoViz` now renders a **proportional** display — commodity column next to stacked reference glyphs on the same pixel-per-meter scale, with shaded right face for depth and a stats grid below.
- Four demo presets (Detroit cottage, Austin ranch, Brooklyn brownstone, Beverly Hills mansion) ship in `lib/demoPresets.ts` and use the manual-fallback path, so the deployed demo works **without depending on Nominatim/OSM availability**.
- `netlify.toml` pins Node 22 + Bun 1.3.11 and disables telemetry; Netlify's bundled `@netlify/plugin-nextjs` runtime handles SSR and API routes automatically.

## Architecture
```
app/
  page.tsx                   Client component; hero + presets + result
  api/{commodities,geocode,footprint,assessor}/route.ts
lib/
  math.ts                    Pure: unit conversions, polygon area, prism height
  commodities.ts             Density constants + pricePerM3 + FALLBACK_PRICES
  scaleReference.ts          REFERENCE_OBJECTS ladder + pickReference()
  urlState.ts                ?address&commodity&sqft&value round-trip
  geocode.ts                 Nominatim, US-only guard
  footprint.ts               Overpass, null when no building
  assessor.ts                Pluggable provider chain (county -> ATTOM -> null)
  livePrices.ts              Server-side price fetcher (stubbed to FALLBACK_PRICES)
  pipeline.ts                computeForState orchestrator
  clientFetchers.ts          Client wrappers over /api/* routes
  demoPresets.ts             Curated offline samples
components/
  AddressInput, CommodityPicker, IsoViz, FallbackForm, ShareButton, DemoPresets
```

## What's stubbed (env vars wire it up later)
- **ATTOM Data assessor** — `lib/assessor.ts` returns `null` until `ATTOM_API_KEY` is set.
- **Live commodity prices** — `lib/livePrices.ts` returns the `FALLBACK_PRICES` snapshot. The response shape includes `fromFallback: true` and `asOf`, so the UI can later show a cached-price disclaimer.

## Test plan
- [x] `bun install` — clean install
- [x] `bun test` — 71/71 pass
- [x] `bun run typecheck` — clean
- [x] `bun run build` — Next.js production build succeeds; static and dynamic routes report sane sizes
- [x] `bun run dev` — homepage 200, `/api/commodities` returns fallback snapshot, geocode errors surface as 404/502 correctly
- [ ] Netlify deploy preview — verify the four demo presets render the proportional viz
- [ ] If Nominatim is reachable from Netlify, enter a real US address (e.g. "350 5th Ave, New York, NY") and confirm the OSM footprint + assessor fallback flow

## URL schema
```
/?address=350+5th+Ave+New+York+NY&commodity=gold
/?address=Brooklyn,+NY+(sample)&commodity=oil&sqft=2400&value=2100000   # manual / preset
```

## Deferred (out of scope for this PR)
- Full isometric canvas rendering with camera modes per the spec
- SVG reference illustrations under `/public/references`
- Smooth CSS transitions when switching commodities
- County-API lookup table population
- Live ATTOM, metals-api, and sugar feed integration
- CI workflow

https://claude.ai/code/session_01Df7Y187BB8uPFqRxkrJbiz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Df7Y187BB8uPFqRxkrJbiz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added demo preset samples to help users quickly explore the app without manual entry
  * Enhanced visualizations with reference glyphs for better context

* **Bug Fixes**
  * Improved error messages with user-friendly guidance for common issues

* **Chores**
  * Added caching headers to improve API response performance
  * Configured Netlify deployment support
  * Enhanced number formatting for improved readability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TimBest/gold_house/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->