### PR TITLE
Post-MVP hardening: code-review cleanup, CI, and next-steps plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Test & build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      NEXT_TELEMETRY_DISABLED: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
+
+      - name: Build
+        run: bun run build

--- a/app/api/footprint/route.ts
+++ b/app/api/footprint/route.ts
@@ -7,10 +7,10 @@ export async function GET(req: Request) {
   const lng = Number(url.searchParams.get("lng"));
   try {
     const result = await fetchFootprint(lat, lng);
-    if (result === null) {
-      return NextResponse.json({ result: null });
-    }
-    return NextResponse.json({ result });
+    return NextResponse.json(
+      { result },
+      { headers: { "cache-control": "public, max-age=3600" } }
+    );
   } catch (err) {
     if (err instanceof FootprintError) {
       return NextResponse.json(

--- a/app/api/geocode/route.ts
+++ b/app/api/geocode/route.ts
@@ -6,7 +6,9 @@ export async function GET(req: Request) {
   const address = url.searchParams.get("address") ?? "";
   try {
     const result = await geocodeAddress(address);
-    return NextResponse.json(result);
+    return NextResponse.json(result, {
+      headers: { "cache-control": "public, max-age=3600" },
+    });
   } catch (err) {
     if (err instanceof GeocodeError) {
       return NextResponse.json(

--- a/components/FallbackForm.tsx
+++ b/components/FallbackForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type FormEvent } from "react";
+import { isPositiveFinite } from "@/lib/math";
 
 export function FallbackForm({
   onSubmit,
@@ -14,8 +15,7 @@ export function FallbackForm({
     e.preventDefault();
     const s = Number(sqft);
     const v = Number(value);
-    if (!Number.isFinite(s) || s <= 0) return;
-    if (!Number.isFinite(v) || v <= 0) return;
+    if (!isPositiveFinite(s) || !isPositiveFinite(v)) return;
     onSubmit({ sqft: s, value: v });
   }
 

--- a/components/IsoViz.tsx
+++ b/components/IsoViz.tsx
@@ -1,11 +1,18 @@
 "use client";
 
 import { COMMODITIES } from "@/lib/commodities";
+import { formatBigUSD, formatMeters } from "@/lib/formatting";
 import type { ComputeResult } from "@/lib/pipeline";
+import type { ReferencePick } from "@/lib/scaleReference";
 
 const VIZ_HEIGHT_PX = 360;
 const COLUMN_WIDTH_PX = 88;
 const REFERENCE_COL_WIDTH_PX = 64;
+// Hard cap on stacked glyphs to keep DOM bounded; beyond this we render
+// the overflow form (×N) even when the reference math has count <= cap.
+const MAX_RENDERED_STACK = 20;
+const MIN_GLYPH_PX = 14;
+const MAX_GLYPH_PX = 140;
 
 export function IsoViz({
   result,
@@ -16,20 +23,12 @@ export function IsoViz({
   const heightM = result.heightM;
   const ref = result.reference;
 
-  // Pixels-per-meter is chosen so the *column* fills VIZ_HEIGHT_PX. The
-  // reference glyph(s) are sized in the same scale, so the side-by-side
-  // comparison is proportionally honest.
   const pxPerMeter = VIZ_HEIGHT_PX / heightM;
   const refGlyphPx = Math.max(
-    14,
-    Math.min(140, ref.object.heightM * pxPerMeter)
+    MIN_GLYPH_PX,
+    Math.min(MAX_GLYPH_PX, ref.object.heightM * pxPerMeter)
   );
-  const columnPx = VIZ_HEIGHT_PX;
-
-  const stackedCount = ref.overflow ? Math.floor(ref.count) : ref.count;
-  // Tilt the column with a tiny shadow on the right face for depth.
-  const lightColor = config.color;
-  const darkColor = darken(lightColor, 0.18);
+  const darkColor = darken(config.color, 0.18);
 
   return (
     <section className="rounded-2xl border border-stone-200 bg-white px-6 py-8 shadow-sm">
@@ -47,78 +46,13 @@ export function IsoViz({
         style={{ height: VIZ_HEIGHT_PX + 40 }}
         aria-label={`Visualization: ${formatMeters(heightM)} tower next to ${ref.label}`}
       >
-        {/* Commodity column */}
-        <div className="flex flex-col items-center">
-          <div
-            className="flex overflow-hidden rounded-t-md shadow-sm"
-            style={{
-              width: COLUMN_WIDTH_PX,
-              height: columnPx,
-            }}
-          >
-            <div
-              style={{
-                background: lightColor,
-                width: "70%",
-                borderRight: `1px solid ${darkColor}`,
-              }}
-            />
-            <div
-              style={{
-                background: darkColor,
-                width: "30%",
-              }}
-            />
-          </div>
-          <div className="mt-2 text-xs font-medium text-stone-500">
-            {config.emoji} {config.label}
-          </div>
-        </div>
-
-        {/* Reference stack */}
-        <div
-          className="flex flex-col items-center justify-end"
-          style={{ width: REFERENCE_COL_WIDTH_PX, height: columnPx }}
-        >
-          {ref.overflow ? (
-            <div
-              className="flex flex-col items-center justify-end"
-              style={{ height: columnPx }}
-            >
-              <div
-                style={{ fontSize: refGlyphPx, lineHeight: 1 }}
-                aria-hidden
-              >
-                {ref.object.glyph}
-              </div>
-              <div className="mt-1 text-xs text-stone-500 text-center">
-                ×{ref.count.toFixed(1)}
-              </div>
-            </div>
-          ) : (
-            <div
-              className="flex flex-col-reverse items-center"
-              style={{ height: columnPx }}
-            >
-              {Array.from({ length: stackedCount }).map((_, i) => (
-                <div
-                  key={i}
-                  style={{
-                    fontSize: refGlyphPx,
-                    lineHeight: 1,
-                    height: refGlyphPx,
-                  }}
-                  aria-hidden
-                >
-                  {ref.object.glyph}
-                </div>
-              ))}
-            </div>
-          )}
-          <div className="mt-2 text-xs font-medium text-stone-500 text-center">
-            {ref.object.label}
-          </div>
-        </div>
+        <CommodityColumn
+          emoji={config.emoji}
+          label={config.label}
+          lightColor={config.color}
+          darkColor={darkColor}
+        />
+        <ReferenceStack ref={ref} glyphPx={refGlyphPx} />
       </div>
 
       <div className="mt-2 border-t border-stone-200" />
@@ -151,20 +85,121 @@ export function IsoViz({
   );
 }
 
-function formatMeters(m: number): string {
-  if (m < 0.1) return `${(m * 100).toFixed(1)} cm`;
-  if (m < 1000) return `${m.toFixed(1)} m`;
-  return `${(m / 1000).toFixed(2)} km`;
+function CommodityColumn({
+  emoji,
+  label,
+  lightColor,
+  darkColor,
+}: {
+  emoji: string;
+  label: string;
+  lightColor: string;
+  darkColor: string;
+}) {
+  return (
+    <div className="flex flex-col items-center">
+      <div
+        className="flex overflow-hidden rounded-t-md shadow-sm"
+        style={{ width: COLUMN_WIDTH_PX, height: VIZ_HEIGHT_PX }}
+      >
+        <div
+          style={{
+            background: lightColor,
+            width: "70%",
+            borderRight: `1px solid ${darkColor}`,
+          }}
+        />
+        <div style={{ background: darkColor, width: "30%" }} />
+      </div>
+      <div className="mt-2 text-xs font-medium text-stone-500">
+        {emoji} {label}
+      </div>
+    </div>
+  );
 }
 
-function formatBigUSD(n: number): string {
-  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(2)}B`;
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return n.toFixed(0);
+function ReferenceStack({
+  ref,
+  glyphPx,
+}: {
+  ref: ReferencePick;
+  glyphPx: number;
+}) {
+  const stackedCount = ref.overflow ? Math.floor(ref.count) : ref.count;
+  const tooManyToStack = stackedCount > MAX_RENDERED_STACK;
+  const useCompact = ref.overflow || tooManyToStack;
+
+  return (
+    <div
+      className="flex flex-col items-center justify-end"
+      style={{ width: REFERENCE_COL_WIDTH_PX, height: VIZ_HEIGHT_PX }}
+    >
+      {useCompact ? (
+        <CompactReference ref={ref} glyphPx={glyphPx} />
+      ) : (
+        <StackedReference
+          glyph={ref.object.glyph}
+          count={stackedCount}
+          glyphPx={glyphPx}
+        />
+      )}
+      <div className="mt-2 text-xs font-medium text-stone-500 text-center">
+        {ref.object.label}
+      </div>
+    </div>
+  );
 }
 
-/** Darken a #RRGGBB hex color by `amount` (0–1). Returns hex. */
+function CompactReference({
+  ref,
+  glyphPx,
+}: {
+  ref: ReferencePick;
+  glyphPx: number;
+}) {
+  const multiplier = ref.overflow ? ref.count.toFixed(1) : String(ref.count);
+  return (
+    <div
+      className="flex flex-col items-center justify-end"
+      style={{ height: VIZ_HEIGHT_PX }}
+    >
+      <div style={{ fontSize: glyphPx, lineHeight: 1 }} aria-hidden>
+        {ref.object.glyph}
+      </div>
+      <div className="mt-1 text-xs text-stone-500 text-center">
+        ×{multiplier}
+      </div>
+    </div>
+  );
+}
+
+function StackedReference({
+  glyph,
+  count,
+  glyphPx,
+}: {
+  glyph: string;
+  count: number;
+  glyphPx: number;
+}) {
+  return (
+    <div
+      className="flex flex-col-reverse items-center"
+      style={{ height: VIZ_HEIGHT_PX }}
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <div
+          key={i}
+          style={{ fontSize: glyphPx, lineHeight: 1, height: glyphPx }}
+          aria-hidden
+        >
+          {glyph}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function darken(hex: string, amount: number): string {
   const m = /^#?([0-9a-f]{6})$/i.exec(hex);
   if (!m) return hex;

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -1,0 +1,171 @@
+# Gold House MVP — Status & Next Steps
+
+_Snapshot taken 2026-05-21. PR #12 (`claude/commodity-visualizer-display-netlify` → `master`) is the working branch._
+
+---
+
+## Where we are
+
+### What's shipping in PR #12
+
+- Next.js 15 (App Router) + React 19 + TypeScript + Tailwind v4 + Bun.
+- 78 tests passing (`bun test`); `bun run typecheck` and `bun run build` clean.
+- Netlify deploy config (`netlify.toml` + explicit `@netlify/plugin-nextjs`).
+- One client page (`app/page.tsx`) with hero, four demo-preset chips, commodity
+  picker, address input, manual-fallback form, share button, error humanizer.
+- Proportional 2D visualization (commodity column + stacked reference glyphs
+  on the same px/m scale, capped at 20 stacked DOM nodes).
+- Four server-side API routes wrapping the lib fetchers with sensible cache
+  headers and status codes.
+
+### Modules complete (all under `lib/`)
+
+| File | Purpose | State |
+|---|---|---|
+| `math.ts` | sqFtToSqM, polygonAreaM2, totalFloorAreaM2, heightOfPrism, isPositiveFinite | ✅ |
+| `commodities.ts` | COMMODITIES table, pricePerM3 conversions, FALLBACK_PRICES | ✅ |
+| `scaleReference.ts` | REFERENCE_OBJECTS ladder + pickReference + glyphs | ✅ (glyphs are emoji stand-ins, not SVG) |
+| `urlState.ts` | URL param round-trip | ✅ |
+| `geocode.ts` | Nominatim client, US-only guard | ✅ |
+| `footprint.ts` | Overpass client | ✅ |
+| `assessor.ts` | Pluggable county → ATTOM → null chain | ⚠️ Both providers stubbed |
+| `livePrices.ts` | Server-side commodity-price fetcher | ⚠️ Returns FALLBACK_PRICES |
+| `pipeline.ts` | computeForState orchestrator | ✅ |
+| `clientFetchers.ts` | Typed wrappers around /api/* | ✅ |
+| `demoPresets.ts` | Four offline sample homes | ✅ |
+| `formatting.ts` | formatMeters, formatBigUSD | ✅ |
+
+### Known limitations vs the spec
+
+1. **Visualization is 2D, not isometric.** Spec sections 7–8 (camera modes,
+   SVG reference illustrations, smooth transitions) are deferred.
+2. **No live commodity prices.** `lib/livePrices.ts` returns the bundled
+   `FALLBACK_PRICES` snapshot. The disclaimer label the spec calls for
+   (`"using cached price as of [date]"`) is not rendered.
+3. **No real assessor data.** Both `countyApiLookup` and `attomLookup` in
+   `lib/assessor.ts` return `null` so the manual-fallback form is shown
+   whenever the user enters an address.
+4. **No address-input debounce.** Spec section 14 calls for 500 ms because of
+   Nominatim's 1 req/sec policy. We only call on submit so it isn't
+   load-bearing today, but type-ahead would need it.
+
+---
+
+## Plan to finish the MVP
+
+### P0 — Confirm the Netlify deploy works
+
+The last user-visible blocker was a 404 from Netlify; the `@netlify/plugin-nextjs`
+fix was pushed but unverified at the time of writing.
+
+- [ ] Open the PR #12 deploy preview URL
+- [ ] Hit `/` — landing page renders with hero + presets
+- [ ] Click each of the four sample-home chips and confirm the viz renders
+- [ ] Try a real US address (e.g. `350 5th Ave, New York, NY`) — confirm the
+      pipeline either renders the result or falls back gracefully (depending on
+      whether Netlify's outbound can reach Nominatim/Overpass)
+- [ ] Toggle commodities and confirm the column re-scales
+
+### P1 — Live commodity prices (highest impact, lowest cost)
+
+The data layer is already wired for this; `lib/livePrices.ts` is the single
+file to change. Each source has a clean fallback to the snapshot in
+`FALLBACK_PRICES`, so a single outage doesn't break the page.
+
+- [ ] **Oil — EIA API** (no key required). Endpoint:
+      `https://api.eia.gov/v2/petroleum/pri/spt/data?...&api_key=NONE` — actually
+      EIA *does* require a free key now; register at https://www.eia.gov/opendata.
+      Wire `EIA_API_KEY` into `livePrices.ts`.
+- [ ] **Gold — metals-api.com** free tier (`METALS_API_KEY`). USD/troy oz spot.
+- [ ] **Sugar — research a feed.** Candidates: Alpha Vantage commodity endpoint
+      (`COMMODITY=SUGAR`), Trading Economics free tier, or scrape ICE delayed.
+      If none free-no-strings, keep the snapshot and document the env var name.
+- [ ] **UI disclaimer** — when any `CommodityPriceSnapshot.fromFallback === true`,
+      render a small caption in `IsoViz` ("Using cached price as of 2025-01-15").
+      The data field already exists; just wire the render.
+- [ ] **Server-side caching** — wrap `fetchLivePrices` with a 5-minute in-memory
+      cache so we don't re-hit the free tiers on every API route call.
+
+### P2 — Real assessor data
+
+This is the spec's third data pillar and the most regulatory-fragmented part.
+
+- [ ] **ATTOM Data free tier** (`ATTOM_API_KEY`). The wrapper in
+      `lib/assessor.ts` already gates on the env var. Implement
+      `attomLookup` against `https://api.developer.attomdata.com/...`.
+- [ ] **County API lookup table.** Start with the top four most-populated US
+      counties: Los Angeles (LA County Assessor portal), Cook (Illinois),
+      Harris (Texas), Maricopa (Arizona). Each has its own quirks; map
+      address→county via the geocode result's `display_name` parsing.
+- [ ] **Server-side cache** — per-address, 24 h. Vercel KV or a simple
+      in-memory Map for now.
+
+### P3 — Real isometric visualization
+
+The user-facing differentiator. Spec sections 7 and 8.
+
+- [ ] **SVG reference illustrations** — create the six SVGs called for in
+      `lib/scaleReference.ts` (`credit-card.svg`, `human.svg`,
+      `telephone-pole.svg`, `statue-of-liberty.svg`, `eiffel-tower.svg`,
+      `burj-khalifa.svg`) and drop them in `/public/references`. Single-color
+      flat outlines per the spec.
+- [ ] **Isometric prism math** — extrude the building polygon upward by
+      `heightM`. Project to 2D via the standard isometric matrix
+      (`x = (X - Y) * cos(30°)`, `y = (X + Y) * sin(30°) - Z`).
+- [ ] **Canvas vs SVG decision** — Canvas is faster for large extrusions;
+      SVG is easier to make responsive and a11y-friendly. Recommend SVG for
+      MVP, swap to Canvas only if perf becomes an issue.
+- [ ] **Camera modes** (spec section 8):
+      `< 2 m` head-on, `2–50 m` 15–20° tilt, `50–500 m` full iso 30°,
+      `> 500 m` wide iso with reference object as a small marker.
+- [ ] **Smooth transitions** — 600 ms ease-in-out CSS transition on the
+      transform when commodity changes.
+
+### P4 — Polish & quality
+
+- [ ] **Component tests** — add `@testing-library/react` + Bun preset, write
+      tests for `AddressInput`, `CommodityPicker`, `FallbackForm`.
+- [ ] **API route tests** — direct tests for the four `/api/*` handlers
+      that don't rely on the live pipeline. Mock `lib/*` via `mock.module`.
+- [ ] **Address debounce** — 500 ms in `AddressInput` if we ever do type-ahead.
+- [ ] **A11y audit** — `aria-pressed` on commodity buttons, focus rings,
+      keyboard nav through presets, color contrast ratios for the picker.
+- [ ] **App-level error boundary** — `app/global-error.tsx`.
+- [ ] **CI** — GitHub Actions workflow: `bun install && bun test && bun run
+      build` on PR. Also add a `bun run lint` step.
+- [ ] **Mobile testing** — actual phone viewport, not just devtools.
+
+### P5 — Nice-to-haves (post-MVP)
+
+- [ ] Bundle-size budget; investigate dropping any unused Tailwind variants.
+- [ ] Lighthouse performance budget.
+- [ ] OG image for shareable URLs.
+- [ ] Light/dark mode toggle.
+- [ ] Saved-address history (would require accounts → out of MVP scope).
+
+---
+
+## Open questions for the user
+
+1. **API keys** — do you want me to register for ATTOM and metals-api free
+   tiers myself, or will you provide keys? They're per-account.
+2. **Visualization scope** — finish the isometric (~1–2 day effort) before
+   shipping, or call the current 2D-proportional version "done enough" and
+   move to data sources?
+3. **County API table** — worth the implementation effort for top-4
+   counties, or rely on ATTOM exclusively until coverage gaps appear?
+4. **CI** — want the GitHub Actions workflow added now?
+5. **Sugar price source** — happy with a permanently-cached snapshot
+   (clearly labelled), or should we add a paid feed?
+
+---
+
+## Recommended next-session focus
+
+If I were picking one thing to push next: **P1 (live prices) + the cached-price
+disclaimer**. It's the lowest-effort highest-impact item, completes the
+"Data Fetching" pillar of the spec, and exercises the fallback-disclaimer
+plumbing that's already wired but unused. Then **P3 (isometric viz)** as the
+visible product-quality lever.
+
+P0 (deploy verification) is a prerequisite for everything visible.

--- a/lib/clientFetchers.ts
+++ b/lib/clientFetchers.ts
@@ -19,11 +19,17 @@ async function getJson<T>(path: string): Promise<T> {
   return body as T;
 }
 
+function buildUrl(path: string, params: Record<string, string | number>): string {
+  const sp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) sp.set(k, String(v));
+  return `${path}?${sp.toString()}`;
+}
+
 export const clientFetchers: Fetchers = {
   geocode: async (address) => {
     try {
       return await getJson<GeocodeResult>(
-        `/api/geocode?address=${encodeURIComponent(address)}`
+        buildUrl("/api/geocode", { address })
       );
     } catch (err) {
       throw new GeocodeError("NO_RESULT", (err as Error).message);
@@ -32,7 +38,7 @@ export const clientFetchers: Fetchers = {
   footprint: async (lat, lng) => {
     try {
       const { result } = await getJson<{ result: FootprintResult | null }>(
-        `/api/footprint?lat=${lat}&lng=${lng}`
+        buildUrl("/api/footprint", { lat, lng })
       );
       return result;
     } catch (err) {
@@ -41,7 +47,7 @@ export const clientFetchers: Fetchers = {
   },
   assessor: async ({ address, lat, lng }: AssessorQuery) => {
     const { result } = await getJson<{ result: AssessorResult | null }>(
-      `/api/assessor?address=${encodeURIComponent(address)}&lat=${lat}&lng=${lng}`
+      buildUrl("/api/assessor", { address, lat, lng })
     );
     return result;
   },

--- a/lib/formatting.ts
+++ b/lib/formatting.ts
@@ -1,0 +1,12 @@
+export function formatMeters(m: number): string {
+  if (m < 0.1) return `${(m * 100).toFixed(1)} cm`;
+  if (m < 1000) return `${m.toFixed(1)} m`;
+  return `${(m / 1000).toFixed(2)} km`;
+}
+
+export function formatBigUSD(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(2)}B`;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toFixed(0);
+}

--- a/lib/math.ts
+++ b/lib/math.ts
@@ -3,6 +3,10 @@ import type { HeightComputationInput, Polygon } from "./types";
 const SQFT_TO_SQM = 0.0929;
 const METERS_PER_DEG_LAT = 111_320;
 
+export function isPositiveFinite(n: unknown): n is number {
+  return typeof n === "number" && Number.isFinite(n) && n > 0;
+}
+
 export function sqFtToSqM(sqft: number): number {
   if (sqft < 0) throw new Error("sqft must be non-negative");
   return sqft * SQFT_TO_SQM;

--- a/lib/urlState.ts
+++ b/lib/urlState.ts
@@ -1,3 +1,4 @@
+import { isPositiveFinite } from "./math";
 import type { CommodityId, UrlState } from "./types";
 
 const VALID_COMMODITIES = new Set<CommodityId>(["gold", "oil", "sugar"]);
@@ -12,8 +13,7 @@ function asCommodity(raw: string | null): CommodityId {
 function asPositiveNumber(raw: string | null): number | undefined {
   if (raw === null) return undefined;
   const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) return undefined;
-  return n;
+  return isPositiveFinite(n) ? n : undefined;
 }
 
 export function parseSearchParams(sp: URLSearchParams): UrlState {

--- a/tests/formatting.test.ts
+++ b/tests/formatting.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { formatBigUSD, formatMeters } from "@/lib/formatting";
+
+describe("formatMeters", () => {
+  test("uses cm under 0.1 m", () => {
+    expect(formatMeters(0.05)).toBe("5.0 cm");
+  });
+
+  test("uses m between 0.1 and 1000", () => {
+    expect(formatMeters(47.3)).toBe("47.3 m");
+    expect(formatMeters(0.5)).toBe("0.5 m");
+  });
+
+  test("uses km at or above 1000 m", () => {
+    expect(formatMeters(1234)).toBe("1.23 km");
+  });
+});
+
+describe("formatBigUSD", () => {
+  test("formats billions", () => {
+    expect(formatBigUSD(1_500_000_000)).toBe("1.50B");
+  });
+  test("formats millions", () => {
+    expect(formatBigUSD(2_300_000)).toBe("2.30M");
+  });
+  test("formats thousands", () => {
+    expect(formatBigUSD(4_500)).toBe("4.5K");
+  });
+  test("formats small numbers as integers", () => {
+    expect(formatBigUSD(42)).toBe("42");
+  });
+});


### PR DESCRIPTION
Stacked on top of the MVP work (PR #12). This PR isolates the three post-MVP commits so they can be reviewed independently.

**Base branch is `claude/commodity-visualizer-base`** (the MVP + Netlify baseline) rather than `master`, so the diff shows exactly these three commits. `master` is still the legacy Rust/Python code — CI can't run there. Once PR #12 lands, this PR can be retargeted to `master`.

## Commits
1. **`refactor: code review cleanup`** — applied findings from a three-agent review:
   - Extracted `formatMeters`/`formatBigUSD` into `lib/formatting.ts` (+ tests)
   - Added `isPositiveFinite` type guard in `lib/math.ts`, reused in `urlState.ts` and `FallbackForm.tsx`
   - Split `IsoViz` into focused subcomponents; capped stacked-glyph DOM at 20 nodes
   - Added `cache-control` headers to `/api/geocode` and `/api/footprint`
   - Centralized URL building in `clientFetchers` via `URLSearchParams`
2. **`docs: next-steps plan`** — `docs/NEXT_STEPS.md`: MVP status snapshot and an ordered P0–P5 plan to finish the spec.
3. **`ci: GitHub Actions workflow`** — `.github/workflows/ci.yml`: runs `bun install --frozen-lockfile`, `bun run typecheck`, `bun test`, `bun run build` on every push to `master` and every PR. Pins Bun 1.3.11; cancels superseded runs via concurrency groups.

## Test plan
- [x] `bun test` — 78/78 pass
- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean
- [ ] CI workflow turns green on this PR (first live run)

## Note
These three commits also exist on PR #12's branch (`claude/commodity-visualizer-display-netlify`) — they were left there intentionally. Whichever PR merges first, git will no-op the duplicates in the other.

https://claude.ai/code/session_01Df7Y187BB8uPFqRxkrJbiz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Df7Y187BB8uPFqRxkrJbiz)_